### PR TITLE
Add basic NovaTalks Intercom integration module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/nova_intercom/__init__.py
+++ b/nova_intercom/__init__.py
@@ -1,0 +1,1 @@
+from .sync import sync_existing_chats, send_new_chat, app

--- a/nova_intercom/sync.py
+++ b/nova_intercom/sync.py
@@ -1,0 +1,68 @@
+import os
+from typing import Iterable, Dict
+
+import requests
+
+INTERCOM_BASE_URL = "https://api.intercom.io"
+
+
+def _get_headers() -> Dict[str, str]:
+    token = os.getenv("INTERCOM_TOKEN")
+    if not token:
+        raise EnvironmentError("INTERCOM_TOKEN environment variable not set")
+    return {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+
+
+def send_new_chat(chat_data: Dict) -> Dict:
+    """Send a chat message to Intercom as a conversation."""
+    url = f"{INTERCOM_BASE_URL}/conversations"
+    payload = {
+        "from": {
+            "type": chat_data.get("from_type", "user"),
+            "id": chat_data.get("user_id"),
+        },
+        "body": chat_data.get("body"),
+    }
+    response = requests.post(url, json=payload, headers=_get_headers())
+    response.raise_for_status()
+    return response.json()
+
+
+def _retrieve_chats_from_novatalks() -> Iterable[Dict]:
+    """Placeholder for retrieving chats from NovaTalks."""
+    # In a real implementation this would query the NovaTalks API.
+    return []
+
+
+def sync_existing_chats() -> None:
+    """Retrieve chats from NovaTalks and send them to Intercom."""
+    chats = _retrieve_chats_from_novatalks()
+    for chat in chats:
+        send_new_chat(chat)
+
+
+try:
+    from fastapi import FastAPI, HTTPException
+    from pydantic import BaseModel
+
+    app = FastAPI()
+
+    class Chat(BaseModel):
+        body: str
+        user_id: str | None = None
+        from_type: str | None = "user"
+
+    @app.post("/nova_intercom/chats")
+    def receive_chat(chat: Chat):
+        try:
+            result = send_new_chat(chat.model_dump())
+            return {"id": result.get("id")}
+        except Exception as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
+except Exception:
+    # FastAPI is optional; if not installed this module still works without the HTTP API.
+    app = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+requests
+fastapi
+pydantic
+uvicorn


### PR DESCRIPTION
## Summary
- add `nova_intercom` package with sync helpers
- expose optional FastAPI endpoint
- specify minimal dependencies

## Testing
- `python -m py_compile nova_intercom/sync.py`

------
https://chatgpt.com/codex/tasks/task_e_6879521eeaf0832c9608f5e1d1f27172